### PR TITLE
Game: dispose _graphics

### DIFF
--- a/TankDriver.App/Game.cs
+++ b/TankDriver.App/Game.cs
@@ -127,5 +127,14 @@ namespace TankDriver
 
 			_spriteBatch.End();
 		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing)
+			{
+				_graphics.Dispose();
+			}
+		}
 	}
 }


### PR DESCRIPTION
I've read MonoGame's `Game` class code, and it's not clear whether `GraphicsDeviceManager` is always disposed or not, so let's get a bit defensive here.

Close #24.
