### PR TITLE
Remove ImageMagick dependency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.csproj]
+indent_size = 2
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /packages/
 
 bin/

--- a/Readme.md
+++ b/Readme.md
@@ -12,9 +12,6 @@ installed and its' executable files available in `PATH` environment variable.
 
 ### Windows
 
-Windows build process relies on `magick` executable file from the
-[ImageMagick][imagemagick] package.
-
 Either use [Visual Studio][visual-studio] to open and build `TankDriver.sln`
 file, or invoke the following commands in developer console:
 
@@ -24,9 +21,6 @@ file, or invoke the following commands in developer console:
 ```
 
 ### Linux
-
-Linux build relies on `convert` executable file from the
-[ImageMagick][imagemagick] package.
 
 You'll need [Mono][mono] and [NuGet][nuget] installed.
 
@@ -105,7 +99,6 @@ Attribution 4.0 International License][cc-by-license].
 [andivionian-status-classifier]: https://github.com/ForNeVeR/andivionian-status-classifier#status-umbra-
 [appveyor]: https://ci.appveyor.com/project/ForNeVeR/tankdriver/branch/develop
 [cc-by-license]: https://creativecommons.org/licenses/by/4.0/
-[imagemagick]: https://www.imagemagick.org/script/index.php
 [mono]: http://www.mono-project.com/
 [monogame]: http://www.monogame.net/
 [nuget]: https://www.nuget.org/

--- a/TankDriver.App/TankDriver.App.csproj
+++ b/TankDriver.App/TankDriver.App.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\SvgBuild.MsBuild.0.0.1\build\SvgBuild.MsBuild.props" Condition="Exists('..\packages\SvgBuild.MsBuild.0.0.1\build\SvgBuild.MsBuild.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -92,19 +93,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <ImageMagick Condition=" '$(OS)' == 'Unix' ">convert</ImageMagick>
-    <ImageMagick Condition=" '$(OS)' != 'Unix' ">magick convert</ImageMagick>
     <ApplicationIcon>$(IntermediateOutputPath)icon.ico</ApplicationIcon>
   </PropertyGroup>
   <Target Name="BeforeCompile" Inputs="resources\icon.svg" Outputs="$(ApplicationIcon)">
-    <ItemGroup>
-      <GeneratedResources Include="$(ApplicationIcon)" />
-    </ItemGroup>
-    <ItemGroup>
-      <FileWrites Include="@(GeneratedResources)" />
-    </ItemGroup>
-    <Message Text="Building image resources…" />
-    <Message Text="ImageMagick binary: $(ImageMagick)" />
-    <Exec Command="$(ImageMagick) -background none resources\icon.svg -resize 128x128 $(ApplicationIcon)" />
+    <SvgBuildTask InputPath="resources\icon.svg" OutputPath="$(ApplicationIcon)" Width="128" Height="128" />
   </Target>
 </Project>

--- a/TankDriver.App/packages.config
+++ b/TankDriver.App/packages.config
@@ -4,4 +4,5 @@
   <package id="NLog" version="4.3.7" targetFramework="net45" />
   <package id="NLog.Config" version="4.3.7" targetFramework="net45" />
   <package id="NLog.Schema" version="4.3.7" targetFramework="net45" />
+  <package id="SvgBuild.MsBuild" version="0.0.1" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 with import <nixpkgs> {}; {
     TankDriverEnv = stdenv.mkDerivation {
         name = "TankDriver";
-        buildInputs = [ imagemagick mesa mono46 dotnetPackages.Nuget xorg.libX11 ];
+        buildInputs = [ mesa mono46 dotnetPackages.Nuget xorg.libX11 ];
         LD_LIBRARY_PATH="${xorg.libX11}/lib:${mesa}/lib";
     };
 }


### PR DESCRIPTION
To fix #35 I've written a small MSBuild-compatible [SvgBuild](https://github.com/ForNeVeR/SvgBuild) utility (and that wasn't an easy task, because we want to support exotic image formats such as `ICO` on exotic platforms such as Mono), and now the issue has a value for ecosystem (because the tool is now available for everyone).

Closes #35.