### PR TITLE
#35: remove imagemagick install step from Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,4 @@
-install:
-    - cinst imagemagick
 before_build:
     - nuget restore
-    - refreshenv
 
 version: 0.1.0.{build}


### PR DESCRIPTION
This PR removes the steps taken to install ImageMagick on Appveyor, because we don't use ImageMagick anymore.